### PR TITLE
EnumeratorIterator should have a `hasNext` method

### DIFF
--- a/src/main/resources/enumerator_iterator.rb
+++ b/src/main/resources/enumerator_iterator.rb
@@ -42,6 +42,8 @@ module Killbill
         def has_next
           !@next.nil?
         end
+        
+        alias_method :hasNext, :has_next
 
         def next
           prev = @next


### PR DESCRIPTION
When calling `search_payments` api for payment plugin, it will raise an exception like this:

``` ruby
 NoMethodError:
      undefined method `hasNext' for #<Killbill::Plugin::Model::EnumeratorIterator:0x2cd3fc29>
    # file:/Users/Larry/.rbenv/versions/jruby-1.7.11/lib/jruby.jar!/jruby/java/java_ext/java.lang.rb:12:in `each'
    # ./spec/ach_chase/base_plugin_spec.rb:145:in `(root)'
```

So we need a `hasNext` method for jruby so that it will do the `each` iteration.